### PR TITLE
Update org logo to match EpicGamesExt

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/EpicGames/.github/main/profile/epic-games-logo.webp" alt="Epic Games" width="320">
+  <img src="https://avatars.githubusercontent.com/u/161372141?s=400&u=7ec68094c5020c7d758bc9d9ce023cb86c21fb80&v=4" alt="Epic Games" width="320">
 </p>
 
 Official GitHub presence for Epic Games with a broad range of Epic-maintained developer tools & technologies. Here you'll find two main types of repositories:


### PR DESCRIPTION
Swaps the EpicGames org profile logo to the shared Epic Games avatar used by the EpicGamesExt org, for visual consistency across both organizations.

**What changes:** only the logo `<img src>` in profile/README.md — from the committed `epic-games-logo.webp` to the Epic Games GitHub avatar URL. Centered layout and width (320) are unchanged. All other README content is untouched.

Renders on the public org landing page at https://github.com/EpicGames.